### PR TITLE
Add tomlplusplus and liblie-group-controllers to run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 564.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ namecxx }}
@@ -66,6 +66,8 @@ outputs:
         # against libbipedal-locomotion-framework
         - manif
         - eigen
+        - liblie-group-controllers
+        - tomlplusplus
 
     test:
       commands:


### PR DESCRIPTION
Users of the C++ library otherwise may have problems, as these header-only libraries are included in a transitive way.